### PR TITLE
Fix default password for root admin in admin installation guide

### DIFF
--- a/unrelease-V1.0.1.0/OpenDID_Installation_Guide-V1.0.0.1.md
+++ b/unrelease-V1.0.1.0/OpenDID_Installation_Guide-V1.0.0.1.md
@@ -865,7 +865,7 @@ Please follow the steps below:
 
 2. On the login page, log in with the following credentials:  
    - ① Email: `admin@opendid.omnione.net`  
-   - ② Password: `omnioneopendid12!@`  
+   - ② Password: `password`  
    - ③ Click the **[SIGN IN]** button to log in.  
    <img src="./images/5-1.ta-login.png" width="400"/>
 

--- a/unrelease-V1.0.1.0/OpenDID_Installation_Guide-V1.0.0.1_ko.md
+++ b/unrelease-V1.0.1.0/OpenDID_Installation_Guide-V1.0.0.1_ko.md
@@ -839,7 +839,7 @@ TA 서버의 DID Document를 블록체인에 등록하고, **가입 증명서 VC
 
 2. 로그인 페이지에서 아래 계정으로 로그인합니다.  
    - ① Email: `admin@opendid.omnione.net`  
-   - ② Password: `omnioneopendid12!@` 
+   - ② Password: `password` 
    - ③ **[SIGN IN]** 버튼을 클릭하여 로그인합니다.  
 <img src="./images/5-1.ta-login.png" width="400"/>
 


### PR DESCRIPTION
## Description  
Corrected the default password value for the root admin in the opendid installation guide documentation.

## Related Issue (Optional)  
<!-- Mention the issue number that this PR addresses. -->  
- Issue # (e.g., #123)

## Changes  
- Fixed incorrect initial password for the root admin in the opendid installation guide  

## Screenshots (Optional)  
<!-- Attach screenshots or GIFs to show the changes, if applicable. -->

## Additional Comments (Optional)  
None
